### PR TITLE
Add initial database schema and repositories

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,4 +42,13 @@ subprojects {
     }
 
     tasks.withType<Test> { useJUnitPlatform() }
+
+    configurations.all {
+        resolutionStrategy {
+            force("org.jetbrains.kotlin:kotlin-stdlib:1.9.22")
+            force("org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22")
+            force("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.22")
+            force("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.22")
+        }
+    }
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -3,7 +3,10 @@ dependencies {
     implementation("org.jetbrains.exposed:exposed-core:0.44.1")
     implementation("org.jetbrains.exposed:exposed-dao:0.44.1")
     implementation("org.jetbrains.exposed:exposed-jdbc:0.44.1")
+    implementation("org.jetbrains.exposed:exposed-java-time:0.44.1")
     implementation("org.flywaydb:flyway-core:9.22.0")
     implementation("com.zaxxer:HikariCP:5.1.0")
     implementation("org.postgresql:postgresql:42.7.2")
+
+    testImplementation("com.h2database:h2:2.2.224")
 }

--- a/data/src/main/kotlin/pl/bot/data/db/Tables.kt
+++ b/data/src/main/kotlin/pl/bot/data/db/Tables.kt
@@ -1,0 +1,64 @@
+package pl.bot.data.db
+
+import org.jetbrains.exposed.dao.id.LongIdTable
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.javatime.date
+import org.jetbrains.exposed.sql.javatime.datetime
+
+object Users : LongIdTable("users") {
+    val name: Column<String> = varchar("name", 255)
+    val email: Column<String> = varchar("email", 255).uniqueIndex()
+}
+
+object RateLimits : LongIdTable("rate_limits") {
+    val userId = reference("user_id", Users)
+    val quotaName = varchar("quota_name", 255)
+    val date = date("date")
+    val quotaLimit = integer("quota_limit")
+    val used = integer("used")
+    init { index("idx_rate_limits_user_quota_date", false, userId, quotaName, date) }
+}
+
+object Alerts : LongIdTable("alerts") {
+    val userId = reference("user_id", Users)
+    val message = varchar("message", 255)
+    val active = bool("active")
+    init { index("idx_alerts_user_active", false, userId, active) }
+}
+
+object CryptoAlerts : LongIdTable("crypto_alerts") {
+    val userId = reference("user_id", Users)
+    val symbol = varchar("symbol", 50)
+    val active = bool("active")
+    init { index("idx_crypto_alerts_user_active", false, userId, active) }
+}
+
+object Portfolios : LongIdTable("portfolios") {
+    val userId = reference("user_id", Users)
+    val name = varchar("name", 255)
+}
+
+object Positions : LongIdTable("positions") {
+    val portfolioId = reference("portfolio_id", Portfolios)
+    val asset = varchar("asset", 255)
+    val quantity = double("quantity")
+}
+
+object Trades : LongIdTable("trades") {
+    val positionId = reference("position_id", Positions)
+    val price = double("price")
+    val quantity = double("quantity")
+    val executedAt = datetime("executed_at")
+}
+
+object Payments : LongIdTable("payments") {
+    val userId = reference("user_id", Users)
+    val amount = double("amount")
+    val createdAt = datetime("created_at")
+}
+
+object Referrals : LongIdTable("referrals") {
+    val userId = reference("user_id", Users)
+    val referredUserId = reference("referred_user_id", Users)
+    val code = varchar("code", 255)
+}

--- a/data/src/main/kotlin/pl/bot/data/repository/Repositories.kt
+++ b/data/src/main/kotlin/pl/bot/data/repository/Repositories.kt
@@ -1,0 +1,236 @@
+package pl.bot.data.repository
+
+import pl.bot.data.db.*
+import java.time.LocalDate
+import java.time.LocalDateTime
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.insertAndGetId
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.transactions.transaction
+
+data class User(val id: Long, val name: String, val email: String)
+
+data class RateLimit(
+    val id: Long,
+    val userId: Long,
+    val quotaName: String,
+    val date: LocalDate,
+    val quotaLimit: Int,
+    val used: Int,
+)
+
+data class Alert(val id: Long, val userId: Long, val message: String, val active: Boolean)
+
+data class CryptoAlert(val id: Long, val userId: Long, val symbol: String, val active: Boolean)
+
+data class Portfolio(val id: Long, val userId: Long, val name: String)
+
+data class Position(val id: Long, val portfolioId: Long, val asset: String, val quantity: Double)
+
+data class Trade(
+    val id: Long,
+    val positionId: Long,
+    val price: Double,
+    val quantity: Double,
+    val executedAt: LocalDateTime,
+)
+
+data class Payment(val id: Long, val userId: Long, val amount: Double, val createdAt: LocalDateTime)
+
+data class Referral(val id: Long, val userId: Long, val referredUserId: Long, val code: String)
+
+class UsersRepository {
+    fun create(name: String, email: String): User = transaction {
+        val id = Users.insertAndGetId {
+            it[Users.name] = name
+            it[Users.email] = email
+        }.value
+        User(id, name, email)
+    }
+
+    fun findById(id: Long): User? = transaction {
+        Users.select { Users.id eq id }.map(::toUser).singleOrNull()
+    }
+
+    private fun toUser(row: ResultRow) =
+        User(row[Users.id].value, row[Users.name], row[Users.email])
+}
+
+class RateLimitsRepository {
+    fun create(userId: Long, quotaName: String, date: LocalDate, quotaLimit: Int, used: Int): RateLimit = transaction {
+        val id = RateLimits.insertAndGetId {
+            it[RateLimits.userId] = userId
+            it[RateLimits.quotaName] = quotaName
+            it[RateLimits.date] = date
+            it[RateLimits.quotaLimit] = quotaLimit
+            it[RateLimits.used] = used
+        }.value
+        RateLimit(id, userId, quotaName, date, quotaLimit, used)
+    }
+
+    fun findById(id: Long): RateLimit? = transaction {
+        RateLimits.select { RateLimits.id eq id }.map(::toRateLimit).singleOrNull()
+    }
+
+    private fun toRateLimit(row: ResultRow) =
+        RateLimit(
+            row[RateLimits.id].value,
+            row[RateLimits.userId].value,
+            row[RateLimits.quotaName],
+            row[RateLimits.date],
+            row[RateLimits.quotaLimit],
+            row[RateLimits.used],
+        )
+}
+
+class AlertsRepository {
+    fun create(userId: Long, message: String, active: Boolean): Alert = transaction {
+        val id = Alerts.insertAndGetId {
+            it[Alerts.userId] = userId
+            it[Alerts.message] = message
+            it[Alerts.active] = active
+        }.value
+        Alert(id, userId, message, active)
+    }
+
+    fun findById(id: Long): Alert? = transaction {
+        Alerts.select { Alerts.id eq id }.map(::toAlert).singleOrNull()
+    }
+
+    private fun toAlert(row: ResultRow) =
+        Alert(row[Alerts.id].value, row[Alerts.userId].value, row[Alerts.message], row[Alerts.active])
+}
+
+class CryptoAlertsRepository {
+    fun create(userId: Long, symbol: String, active: Boolean): CryptoAlert = transaction {
+        val id = CryptoAlerts.insertAndGetId {
+            it[CryptoAlerts.userId] = userId
+            it[CryptoAlerts.symbol] = symbol
+            it[CryptoAlerts.active] = active
+        }.value
+        CryptoAlert(id, userId, symbol, active)
+    }
+
+    fun findById(id: Long): CryptoAlert? = transaction {
+        CryptoAlerts.select { CryptoAlerts.id eq id }.map(::toCryptoAlert).singleOrNull()
+    }
+
+    private fun toCryptoAlert(row: ResultRow) =
+        CryptoAlert(
+            row[CryptoAlerts.id].value,
+            row[CryptoAlerts.userId].value,
+            row[CryptoAlerts.symbol],
+            row[CryptoAlerts.active],
+        )
+}
+
+class PortfoliosRepository {
+    fun create(userId: Long, name: String): Portfolio = transaction {
+        val id = Portfolios.insertAndGetId {
+            it[Portfolios.userId] = userId
+            it[Portfolios.name] = name
+        }.value
+        Portfolio(id, userId, name)
+    }
+
+    fun findById(id: Long): Portfolio? = transaction {
+        Portfolios.select { Portfolios.id eq id }.map(::toPortfolio).singleOrNull()
+    }
+
+    private fun toPortfolio(row: ResultRow) =
+        Portfolio(row[Portfolios.id].value, row[Portfolios.userId].value, row[Portfolios.name])
+}
+
+class PositionsRepository {
+    fun create(portfolioId: Long, asset: String, quantity: Double): Position = transaction {
+        val id = Positions.insertAndGetId {
+            it[Positions.portfolioId] = portfolioId
+            it[Positions.asset] = asset
+            it[Positions.quantity] = quantity
+        }.value
+        Position(id, portfolioId, asset, quantity)
+    }
+
+    fun findById(id: Long): Position? = transaction {
+        Positions.select { Positions.id eq id }.map(::toPosition).singleOrNull()
+    }
+
+    private fun toPosition(row: ResultRow) =
+        Position(
+            row[Positions.id].value,
+            row[Positions.portfolioId].value,
+            row[Positions.asset],
+            row[Positions.quantity],
+        )
+}
+
+class TradesRepository {
+    fun create(positionId: Long, price: Double, quantity: Double, executedAt: LocalDateTime): Trade = transaction {
+        val id = Trades.insertAndGetId {
+            it[Trades.positionId] = positionId
+            it[Trades.price] = price
+            it[Trades.quantity] = quantity
+            it[Trades.executedAt] = executedAt
+        }.value
+        Trade(id, positionId, price, quantity, executedAt)
+    }
+
+    fun findById(id: Long): Trade? = transaction {
+        Trades.select { Trades.id eq id }.map(::toTrade).singleOrNull()
+    }
+
+    private fun toTrade(row: ResultRow) =
+        Trade(
+            row[Trades.id].value,
+            row[Trades.positionId].value,
+            row[Trades.price],
+            row[Trades.quantity],
+            row[Trades.executedAt],
+        )
+}
+
+class PaymentsRepository {
+    fun create(userId: Long, amount: Double, createdAt: LocalDateTime): Payment = transaction {
+        val id = Payments.insertAndGetId {
+            it[Payments.userId] = userId
+            it[Payments.amount] = amount
+            it[Payments.createdAt] = createdAt
+        }.value
+        Payment(id, userId, amount, createdAt)
+    }
+
+    fun findById(id: Long): Payment? = transaction {
+        Payments.select { Payments.id eq id }.map(::toPayment).singleOrNull()
+    }
+
+    private fun toPayment(row: ResultRow) =
+        Payment(
+            row[Payments.id].value,
+            row[Payments.userId].value,
+            row[Payments.amount],
+            row[Payments.createdAt],
+        )
+}
+
+class ReferralsRepository {
+    fun create(userId: Long, referredUserId: Long, code: String): Referral = transaction {
+        val id = Referrals.insertAndGetId {
+            it[Referrals.userId] = userId
+            it[Referrals.referredUserId] = referredUserId
+            it[Referrals.code] = code
+        }.value
+        Referral(id, userId, referredUserId, code)
+    }
+
+    fun findById(id: Long): Referral? = transaction {
+        Referrals.select { Referrals.id eq id }.map(::toReferral).singleOrNull()
+    }
+
+    private fun toReferral(row: ResultRow) =
+        Referral(
+            row[Referrals.id].value,
+            row[Referrals.userId].value,
+            row[Referrals.referredUserId].value,
+            row[Referrals.code],
+        )
+}

--- a/data/src/main/resources/db/migration/V1__init.sql
+++ b/data/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,66 @@
+CREATE TABLE users (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE
+);
+
+CREATE TABLE rate_limits (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    quota_name VARCHAR(255) NOT NULL,
+    date DATE NOT NULL,
+    quota_limit INT NOT NULL,
+    used INT NOT NULL DEFAULT 0
+);
+CREATE INDEX idx_rate_limits_user_quota_date ON rate_limits (user_id, quota_name, date);
+
+CREATE TABLE alerts (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    message VARCHAR(255) NOT NULL,
+    active BOOLEAN NOT NULL
+);
+CREATE INDEX idx_alerts_user_active ON alerts (user_id, active);
+
+CREATE TABLE crypto_alerts (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    symbol VARCHAR(50) NOT NULL,
+    active BOOLEAN NOT NULL
+);
+CREATE INDEX idx_crypto_alerts_user_active ON crypto_alerts (user_id, active);
+
+CREATE TABLE portfolios (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    name VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE positions (
+    id BIGSERIAL PRIMARY KEY,
+    portfolio_id BIGINT NOT NULL REFERENCES portfolios(id),
+    asset VARCHAR(255) NOT NULL,
+    quantity DOUBLE PRECISION NOT NULL
+);
+
+CREATE TABLE trades (
+    id BIGSERIAL PRIMARY KEY,
+    position_id BIGINT NOT NULL REFERENCES positions(id),
+    price DOUBLE PRECISION NOT NULL,
+    quantity DOUBLE PRECISION NOT NULL,
+    executed_at TIMESTAMP NOT NULL
+);
+
+CREATE TABLE payments (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    amount DOUBLE PRECISION NOT NULL,
+    created_at TIMESTAMP NOT NULL
+);
+
+CREATE TABLE referrals (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    referred_user_id BIGINT NOT NULL REFERENCES users(id),
+    code VARCHAR(255) NOT NULL
+);

--- a/data/src/test/kotlin/pl/bot/data/RepositoryTest.kt
+++ b/data/src/test/kotlin/pl/bot/data/RepositoryTest.kt
@@ -1,0 +1,70 @@
+package pl.bot.data
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import javax.sql.DataSource
+import org.flywaydb.core.Flyway
+import org.h2.jdbcx.JdbcDataSource
+import org.jetbrains.exposed.sql.Database
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import pl.bot.data.repository.*
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RepositoryTest {
+    private lateinit var dataSource: DataSource
+
+    @BeforeAll
+    fun setup() {
+        dataSource = JdbcDataSource().apply {
+            setURL("jdbc:h2:mem:test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;")
+        }
+        Flyway.configure().dataSource(dataSource).locations("classpath:db/migration").load().migrate()
+        Database.connect(dataSource)
+    }
+
+    @Test
+    fun `repositories basic operations`() {
+        val usersRepo = UsersRepository()
+        val rateLimitsRepo = RateLimitsRepository()
+        val alertsRepo = AlertsRepository()
+        val cryptoAlertsRepo = CryptoAlertsRepository()
+        val portfoliosRepo = PortfoliosRepository()
+        val positionsRepo = PositionsRepository()
+        val tradesRepo = TradesRepository()
+        val paymentsRepo = PaymentsRepository()
+        val referralsRepo = ReferralsRepository()
+
+        val user = usersRepo.create("Alice", "alice@example.com")
+        assertEquals(user, usersRepo.findById(user.id))
+
+        val rateLimit = rateLimitsRepo.create(user.id, "daily", LocalDate.now(), 10, 1)
+        assertEquals(rateLimit, rateLimitsRepo.findById(rateLimit.id))
+
+        val alert = alertsRepo.create(user.id, "hello", true)
+        assertEquals(alert, alertsRepo.findById(alert.id))
+
+        val cryptoAlert = cryptoAlertsRepo.create(user.id, "BTC", false)
+        assertEquals(cryptoAlert, cryptoAlertsRepo.findById(cryptoAlert.id))
+
+        val portfolio = portfoliosRepo.create(user.id, "Main")
+        assertEquals(portfolio, portfoliosRepo.findById(portfolio.id))
+
+        val position = positionsRepo.create(portfolio.id, "AAPL", 5.0)
+        assertEquals(position, positionsRepo.findById(position.id))
+
+        val tradeTime = LocalDateTime.now().withNano(0)
+        val trade = tradesRepo.create(position.id, 150.0, 2.0, tradeTime)
+        assertEquals(trade, tradesRepo.findById(trade.id))
+
+        val paymentTime = LocalDateTime.now().withNano(0)
+        val payment = paymentsRepo.create(user.id, 100.0, paymentTime)
+        assertEquals(payment, paymentsRepo.findById(payment.id))
+
+        val referred = usersRepo.create("Bob", "bob@example.com")
+        val referral = referralsRepo.create(user.id, referred.id, "CODE")
+        assertEquals(referral, referralsRepo.findById(referral.id))
+    }
+}


### PR DESCRIPTION
## Summary
- define Users, RateLimits, Alerts, CryptoAlerts, Portfolios, Positions, Trades, Payments and Referrals tables
- add corresponding Exposed table objects, repositories and Flyway migration
- add H2-backed tests covering basic repository operations

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6897f84950e08321a63d085ab92a09fb