### PR TITLE
feat: add telegram webhook

### DIFF
--- a/bot/src/main/kotlin/Application.kt
+++ b/bot/src/main/kotlin/Application.kt
@@ -15,6 +15,10 @@ import pl.bot.infra.clientsModule
 import pl.bot.infra.repositoriesModule
 import pl.bot.infra.servicesModule
 import pl.bot.metrics.prometheusRegistry
+import com.pengrad.telegrambot.TelegramBot
+import com.pengrad.telegrambot.model.BotCommand
+import com.pengrad.telegrambot.request.SetMyCommands
+import pl.bot.infra.Config
 
 fun main() {
     embeddedServer(Netty, port = 8080, module = Application::module).start(wait = true)
@@ -26,9 +30,32 @@ fun Application.module() {
     install(StatusPages)
     install(MicrometerMetrics) { registry = prometheusRegistry }
     install(Koin) { modules(clientsModule, repositoriesModule, servicesModule) }
+    val config = Config.fromEnv()
+    val bot = TelegramBot(config.telegramToken)
+    setupCommands(bot)
     routing {
         get("/healthz") { call.respondText("OK") }
         get("/readyz") { call.respondText("OK") }
         get("/metrics") { call.respondText(prometheusRegistry.scrape()) }
+        telegramWebhook(bot)
     }
+}
+
+private fun setupCommands(bot: TelegramBot) {
+    val commands = arrayOf(
+        BotCommand("start", "Старт"),
+        BotCommand("help", "Помощь"),
+        BotCommand("upgrade", "Тарифы"),
+        BotCommand("quote", "Котировка"),
+        BotCommand("options", "Опционы"),
+        BotCommand("dividends", "Дивиденды"),
+        BotCommand("portfolio", "Портфель"),
+        BotCommand("alert", "Алерт"),
+        BotCommand("cquote", "Крипто котировка"),
+        BotCommand("calert", "Крипто алерт"),
+        BotCommand("cgainers", "Лидеры роста"),
+        BotCommand("convert", "Конвертация"),
+        BotCommand("cfear", "Индекс страха"),
+    )
+    bot.execute(SetMyCommands(*commands).languageCode("ru"))
 }

--- a/bot/src/main/kotlin/Decorators.kt
+++ b/bot/src/main/kotlin/Decorators.kt
@@ -1,0 +1,29 @@
+package pl.bot.bot
+
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.FUNCTION
+
+// Subscription plans
+enum class Plan { FREE, PRO, PREMIUM }
+
+@Target(FUNCTION)
+@Retention(RUNTIME)
+annotation class RequiresPlan(val plan: Plan)
+
+@Target(FUNCTION)
+@Retention(RUNTIME)
+annotation class Quota(val name: String, val dailyLimit: Int)
+
+class RateLimiter {
+    private val usage = mutableMapOf<Pair<Long, String>, Pair<java.time.LocalDate, Int>>()
+
+    fun checkAndIncrement(userId: Long, quotaName: String, limit: Int): Boolean {
+        val today = java.time.LocalDate.now()
+        val key = userId to quotaName
+        val (date, count) = usage[key] ?: today to 0
+        val current = if (date == today) count else 0
+        if (current >= limit) return false
+        usage[key] = today to (current + 1)
+        return true
+    }
+}

--- a/bot/src/main/kotlin/TelegramWebhook.kt
+++ b/bot/src/main/kotlin/TelegramWebhook.kt
@@ -1,0 +1,138 @@
+package pl.bot.bot
+
+import com.pengrad.telegrambot.utility.BotUtils
+import com.pengrad.telegrambot.TelegramBot
+import com.pengrad.telegrambot.model.Update
+import com.pengrad.telegrambot.request.SendMessage
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import kotlin.reflect.KFunction2
+import kotlin.reflect.full.findAnnotation
+
+fun Route.telegramWebhook(bot: TelegramBot, rateLimiter: RateLimiter = RateLimiter()) {
+    post("/tg/webhook") {
+        val json = call.receiveText()
+        val update = BotUtils.fromJson(json, Update::class.java)
+        processUpdate(bot, rateLimiter, update)
+        call.respond(HttpStatusCode.OK)
+    }
+}
+
+fun processUpdate(bot: TelegramBot, rateLimiter: RateLimiter, update: Update) {
+    val message = update.message() ?: return
+    val chatId = message.chat().id()
+    val userId = message.from().id()
+    val command = message.text()?.split(" ")?.firstOrNull() ?: ""
+
+    fun exec(handler: KFunction2<TelegramBot, Update, Unit>) {
+        handler.findAnnotation<Quota>()?.let { quota ->
+            if (!rateLimiter.checkAndIncrement(userId, quota.name, quota.dailyLimit)) {
+                bot.execute(SendMessage(chatId, "Квота исчерпана"))
+                return
+            }
+        }
+        handler.findAnnotation<RequiresPlan>()?.let { req ->
+            val userPlan = userPlan(userId)
+            if (userPlan.ordinal < req.plan.ordinal) {
+                bot.execute(SendMessage(chatId, "Требуется план ${req.plan}"))
+                return
+            }
+        }
+        handler.call(bot, update)
+    }
+
+    when (command) {
+        "/start" -> exec(::start)
+        "/help" -> exec(::help)
+        "/upgrade" -> exec(::upgrade)
+        "/quote" -> exec(::quote)
+        "/options" -> exec(::options)
+        "/dividends" -> exec(::dividends)
+        "/portfolio" -> exec(::portfolio)
+        "/alert" -> exec(::alert)
+        "/cquote" -> exec(::cquote)
+        "/calert" -> exec(::calert)
+        "/cgainers" -> exec(::cgainers)
+        "/convert" -> exec(::convert)
+        "/cfear" -> exec(::cfear)
+        else -> bot.execute(SendMessage(chatId, "Неизвестная команда"))
+    }
+}
+
+private fun userPlan(@Suppress("UNUSED_PARAMETER") userId: Long): Plan = Plan.FREE
+
+@RequiresPlan(Plan.FREE)
+fun start(bot: TelegramBot, update: Update) {
+    bot.execute(SendMessage(update.message().chat().id(), "Добро пожаловать!"))
+}
+
+@RequiresPlan(Plan.FREE)
+fun help(bot: TelegramBot, update: Update) {
+    bot.execute(SendMessage(update.message().chat().id(), "Помощь"))
+}
+
+@RequiresPlan(Plan.FREE)
+fun upgrade(bot: TelegramBot, update: Update) {
+    bot.execute(SendMessage(update.message().chat().id(), "Доступные тарифы: PRO, PREMIUM"))
+}
+
+@RequiresPlan(Plan.FREE)
+@Quota("quote", 10)
+fun quote(bot: TelegramBot, update: Update) {
+    bot.execute(SendMessage(update.message().chat().id(), "Quote stub"))
+}
+
+@RequiresPlan(Plan.PRO)
+fun options(bot: TelegramBot, update: Update) {
+    bot.execute(SendMessage(update.message().chat().id(), "Options stub"))
+}
+
+@RequiresPlan(Plan.PRO)
+fun dividends(bot: TelegramBot, update: Update) {
+    bot.execute(SendMessage(update.message().chat().id(), "Dividends stub"))
+}
+
+@RequiresPlan(Plan.FREE)
+fun portfolio(bot: TelegramBot, update: Update) {
+    val chatId = update.message().chat().id()
+    val parts = update.message().text().split(" ")
+    val reply = when (parts.getOrNull(1)) {
+        "add" -> "Добавление в портфель (stub)"
+        "show" -> "Портфель (stub)"
+        else -> "Используйте /portfolio add|show"
+    }
+    bot.execute(SendMessage(chatId, reply))
+}
+
+@RequiresPlan(Plan.PRO)
+fun alert(bot: TelegramBot, update: Update) {
+    bot.execute(SendMessage(update.message().chat().id(), "Alert stub"))
+}
+
+@RequiresPlan(Plan.PRO)
+fun cquote(bot: TelegramBot, update: Update) {
+    bot.execute(SendMessage(update.message().chat().id(), "Crypto quote stub"))
+}
+
+@RequiresPlan(Plan.PRO)
+fun calert(bot: TelegramBot, update: Update) {
+    bot.execute(SendMessage(update.message().chat().id(), "Crypto alert stub"))
+}
+
+@RequiresPlan(Plan.PRO)
+fun cgainers(bot: TelegramBot, update: Update) {
+    bot.execute(SendMessage(update.message().chat().id(), "Crypto gainers stub"))
+}
+
+@RequiresPlan(Plan.PREMIUM)
+fun convert(bot: TelegramBot, update: Update) {
+    bot.execute(SendMessage(update.message().chat().id(), "Convert stub"))
+}
+
+@RequiresPlan(Plan.PRO)
+fun cfear(bot: TelegramBot, update: Update) {
+    bot.execute(SendMessage(update.message().chat().id(), "Crypto fear index stub"))
+}

--- a/bot/src/test/kotlin/pl/bot/bot/WebhookRoutingTest.kt
+++ b/bot/src/test/kotlin/pl/bot/bot/WebhookRoutingTest.kt
@@ -1,0 +1,38 @@
+package pl.bot.bot
+
+import com.pengrad.telegrambot.utility.BotUtils
+import com.pengrad.telegrambot.TelegramBot
+import com.pengrad.telegrambot.request.BaseRequest
+import com.pengrad.telegrambot.request.SendMessage
+import com.pengrad.telegrambot.response.BaseResponse
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+
+class FakeTelegramBot : TelegramBot("TEST") {
+    var lastRequest: BaseRequest<*, *>? = null
+    override fun <T : BaseRequest<T, R>, R : BaseResponse> execute(request: BaseRequest<T, R>): R {
+        lastRequest = request
+        val json = "{" + "\"ok\":true" + "}"
+        return BotUtils.fromJson(json, request.responseType)
+    }
+}
+
+class WebhookRoutingTest {
+    @Test
+    fun `parses update and routes start command`() {
+        val bot = FakeTelegramBot()
+        val json = """
+            {"update_id":1,
+             "message":{"message_id":1,
+                        "from":{"id":1,"is_bot":false,"first_name":"A"},
+                        "chat":{"id":1,"type":"private"},
+                        "date":0,
+                        "text":"/start"}}
+        """.trimIndent()
+        val update = BotUtils.fromJson(json, com.pengrad.telegrambot.model.Update::class.java)
+        processUpdate(bot, RateLimiter(), update)
+        val request = bot.lastRequest as SendMessage
+        val params = request.parameters
+        assertEquals("Добро пожаловать!", params["text"])
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ subprojects {
     }
 
     dependencies {
-        add("implementation", "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
+        add("implementation", "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
         add("implementation", "org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
         add("testImplementation", "org.junit.jupiter:junit-jupiter:5.10.2")
         add("testImplementation", "io.mockk:mockk:1.14.5")
@@ -49,6 +49,10 @@ subprojects {
             force("org.jetbrains.kotlin:kotlin-stdlib-common:1.9.22")
             force("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.22")
             force("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.22")
+            force("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+            force("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.7.3")
+            force("org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.7.3")
+            force("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
         }
     }
 }


### PR DESCRIPTION
## Summary
- add Telegram webhook route with command routing
- configure Telegram command list at startup
- add plan/quota decorators with simple rate limiter
- cover update parsing and routing with unit test

## Testing
- `./gradlew cleanTest test`

------
https://chatgpt.com/codex/tasks/task_e_6897fd9cb44c8321813e0ee67dee95dd