### PR TITLE
Add Tinkoff WS client with Redis publishing and tests

### DIFF
--- a/clients/src/main/kotlin/pl/bot/clients/redis/Publisher.kt
+++ b/clients/src/main/kotlin/pl/bot/clients/redis/Publisher.kt
@@ -1,0 +1,29 @@
+package pl.bot.clients.redis
+
+import io.lettuce.core.RedisClient
+import io.lettuce.core.api.async.RedisAsyncCommands
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.withContext
+
+interface Publisher {
+    suspend fun publish(channel: String, message: String)
+}
+
+class RedisPublisher(redisUri: String) : Publisher {
+    private val client = RedisClient.create(redisUri)
+    private val connection = client.connect()
+    private val commands: RedisAsyncCommands<String, String> = connection.async()
+
+    override suspend fun publish(channel: String, message: String) {
+        withContext(Dispatchers.IO) { commands.publish(channel, message).toCompletableFuture().await() }
+    }
+}
+
+class InMemoryPublisher : Publisher {
+    val messages = mutableMapOf<String, MutableList<String>>()
+    override suspend fun publish(channel: String, message: String) {
+        messages.getOrPut(channel) { mutableListOf() }.add(message)
+    }
+}
+

--- a/clients/src/main/kotlin/pl/bot/clients/tinkoff/TinkoffWsClient.kt
+++ b/clients/src/main/kotlin/pl/bot/clients/tinkoff/TinkoffWsClient.kt
@@ -1,0 +1,147 @@
+package pl.bot.clients.tinkoff
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.webSocketSession
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import io.ktor.websocket.Frame
+import io.ktor.websocket.close
+import io.ktor.websocket.readText
+import io.ktor.websocket.send
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.decodeFromString
+import pl.bot.clients.redis.Publisher
+
+private const val WS_URL = "wss://invest-public-api.tinkoff.ru/ws/"
+
+/** Connection abstraction for easier testing. */
+interface WsSession {
+    suspend fun send(text: String)
+    suspend fun receive(): String?
+    suspend fun close()
+}
+
+/** Factory creating [WsSession] instances. */
+interface WsConnector {
+    suspend fun connect(token: String): WsSession
+}
+
+/** Real connector based on Ktor [HttpClient]. */
+class KtorWsConnector(
+    private val engine: HttpClientEngine = CIO.create()
+) : WsConnector {
+    private val client = HttpClient(engine) { install(WebSockets) }
+
+    override suspend fun connect(token: String): WsSession {
+        val session = client.webSocketSession(urlString = WS_URL) {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }
+        return object : WsSession {
+            override suspend fun send(text: String) {
+                session.send(Frame.Text(text))
+            }
+
+            override suspend fun receive(): String? {
+                val frame = session.incoming.receiveCatching().getOrNull() ?: return null
+                return (frame as? Frame.Text)?.readText()
+            }
+
+            override suspend fun close() {
+                session.close()
+            }
+        }
+    }
+}
+
+@Serializable
+private data class SubscribeRequest(
+    val event: String = "subscribe",
+    val quotes: List<String>,
+    val orderbooks: List<String>
+)
+
+@Serializable
+private data class LastPriceEvent(val type: String = "last_price", val figi: String, val price: Double)
+
+@Serializable
+private data class OrderBookEvent(
+    val type: String = "orderbook",
+    val figi: String,
+    val bids: List<List<Double>>,
+    val asks: List<List<Double>>
+)
+
+class TinkoffWsClient(
+    private val token: String,
+    private val connector: WsConnector,
+    private val publisher: Publisher,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+) {
+    suspend fun run(secids: List<String>) {
+        val backoff = Backoff()
+        while (scope.isActive) {
+            try {
+                val session = connector.connect(token)
+                backoff.reset()
+                session.send(json.encodeToString(SubscribeRequest(quotes = secids, orderbooks = secids)))
+                val heartbeat = scope.launch {
+                    while (isActive) {
+                        delay(10_000)
+                        session.send("""{"type":"ping"}""")
+                    }
+                }
+                while (true) {
+                    val text = session.receive() ?: break
+                    handleMessage(text)
+                }
+                heartbeat.cancel()
+                session.close()
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                delay(backoff.nextDelay())
+            }
+        }
+    }
+
+    private suspend fun handleMessage(text: String) {
+        val obj = json.decodeFromString<JsonObject>(text)
+        when (obj["type"]?.jsonPrimitive?.content) {
+            "last_price" -> {
+                val event = json.decodeFromString<LastPriceEvent>(text)
+                publisher.publish("prices:${event.figi}", event.price.toString())
+            }
+            "orderbook" -> {
+                val event = json.decodeFromString<OrderBookEvent>(text)
+                publisher.publish("orderbook:${event.figi}", json.encodeToString(event))
+            }
+        }
+    }
+
+    private class Backoff(
+        private val base: Long = 1_000L,
+        private val max: Long = 60_000L
+    ) {
+        private var current = base
+        fun reset() { current = base }
+        suspend fun nextDelay(): Long {
+            val d = current
+            current = (current * 2).coerceAtMost(max)
+            return d
+        }
+    }
+}
+

--- a/clients/src/test/kotlin/pl/bot/clients/tinkoff/TinkoffWsClientTest.kt
+++ b/clients/src/test/kotlin/pl/bot/clients/tinkoff/TinkoffWsClientTest.kt
@@ -1,0 +1,66 @@
+package pl.bot.clients.tinkoff
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.cancel
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import pl.bot.clients.redis.InMemoryPublisher
+
+private class MockWsSession(private val messages: List<String>) : WsSession {
+    private val iterator = messages.iterator()
+    val sent = mutableListOf<String>()
+    override suspend fun send(text: String) { sent.add(text) }
+    override suspend fun receive(): String? = if (iterator.hasNext()) iterator.next() else null
+    override suspend fun close() {}
+}
+
+private class MockWsConnector(private val sessions: MutableList<MockWsSession>) : WsConnector {
+    override suspend fun connect(token: String): WsSession {
+        if (sessions.isEmpty()) error("no sessions")
+        return sessions.removeAt(0)
+    }
+}
+
+class TinkoffWsClientTest {
+    @Test
+    fun `parses events and publishes`() = runBlocking {
+        val session = MockWsSession(listOf(
+            """{"type":"last_price","figi":"AAA","price":100.0}""",
+            """{"type":"orderbook","figi":"AAA","bids":[[1.0,2.0]],"asks":[[3.0,4.0]]}"""
+        ))
+        val connector = MockWsConnector(mutableListOf(session))
+        val publisher = InMemoryPublisher()
+        val scope = CoroutineScope(Dispatchers.Default + Job())
+        val client = TinkoffWsClient("token", connector, publisher, scope = scope)
+        val job = scope.launch { client.run(listOf("AAA")) }
+        delay(50)
+        scope.cancel()
+        job.join()
+        assertEquals(listOf("100.0"), publisher.messages["prices:AAA"])
+        assertEquals(1, publisher.messages["orderbook:AAA"]?.size)
+        assertEquals(true, session.sent.first().contains("AAA"))
+    }
+
+    @Test
+    fun `reconnects after close`() = runBlocking {
+        val s1 = MockWsSession(listOf("""{"type":"last_price","figi":"AAA","price":100.0}"""))
+        val s2 = MockWsSession(listOf("""{"type":"last_price","figi":"AAA","price":101.0}"""))
+        val connector = MockWsConnector(mutableListOf(s1, s2))
+        val publisher = InMemoryPublisher()
+        val scope = CoroutineScope(Dispatchers.Default + Job())
+        val client = TinkoffWsClient("token", connector, publisher, scope = scope)
+        val job = scope.launch { client.run(listOf("AAA")) }
+        delay(100)
+        scope.cancel()
+        job.join()
+        assertEquals(listOf("100.0", "101.0"), publisher.messages["prices:AAA"])
+        assertEquals(1, s1.sent.size)
+        assertEquals(1, s2.sent.size)
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement TinkoffWsClient with reconnect, heartbeat and Redis pub/sub
- add Redis publisher abstraction with in-memory test implementation
- cover websocket client with parsing and reconnection tests

## Testing
- `./gradlew :clients:test`

------
https://chatgpt.com/codex/tasks/task_e_6898078df3588321b46f0a5e11975ae4