### PR TITLE
Add cryptocurrency and sentiment API clients

### DIFF
--- a/clients/src/main/kotlin/pl/bot/clients/binance/BinanceClient.kt
+++ b/clients/src/main/kotlin/pl/bot/clients/binance/BinanceClient.kt
@@ -1,0 +1,148 @@
+package pl.bot.clients.binance
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.parameters
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.long
+import pl.bot.clients.cache.Cache
+
+private const val BASE_URL = "https://api.binance.com"
+
+@Serializable
+data class Ticker24h(
+    val symbol: String,
+    val lastPrice: Double,
+    val priceChangePercent: Double,
+    val highPrice: Double,
+    val lowPrice: Double,
+    val volume: Double,
+)
+
+@Serializable
+data class Order(
+    val price: Double,
+    val quantity: Double,
+)
+
+@Serializable
+data class OrderBook(
+    val bids: List<Order>,
+    val asks: List<Order>,
+)
+
+@Serializable
+data class Kline(
+    val openTime: Long,
+    val open: Double,
+    val high: Double,
+    val low: Double,
+    val close: Double,
+    val volume: Double,
+    val closeTime: Long,
+)
+
+class BinanceClient(
+    private val cache: Cache,
+    engine: HttpClientEngine = CIO.create(),
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+    private val http = HttpClient(engine) {
+        install(ContentNegotiation) { json(json) }
+        install(HttpTimeout) {
+            requestTimeoutMillis = 5_000
+            connectTimeoutMillis = 5_000
+            socketTimeoutMillis = 5_000
+        }
+        install(HttpRequestRetry) {
+            retryOnExceptionOrServerErrors(maxRetries = 2)
+            exponentialDelay()
+        }
+    }
+
+    suspend fun ticker24h(symbol: String): Ticker24h {
+        val key = "bn:ticker:$symbol"
+        cache.get(key)?.let { return json.decodeFromString(Ticker24h.serializer(), it) }
+        val body = http.get("${'$'}BASE_URL/api/v3/ticker/24hr") {
+            url { parameters.append("symbol", symbol) }
+        }.bodyAsText()
+        val obj = json.parseToJsonElement(body).jsonObject
+        val ticker = Ticker24h(
+            symbol = obj["symbol"]!!.jsonPrimitive.content,
+            lastPrice = obj["lastPrice"]!!.jsonPrimitive.double,
+            priceChangePercent = obj["priceChangePercent"]!!.jsonPrimitive.double,
+            highPrice = obj["highPrice"]!!.jsonPrimitive.double,
+            lowPrice = obj["lowPrice"]!!.jsonPrimitive.double,
+            volume = obj["volume"]!!.jsonPrimitive.double,
+        )
+        cache.set(key, json.encodeToString(Ticker24h.serializer(), ticker), 5)
+        return ticker
+    }
+
+    suspend fun depth(symbol: String, limit: Int = 10): OrderBook {
+        val key = "bn:depth:$symbol:$limit"
+        cache.get(key)?.let { return json.decodeFromString(OrderBook.serializer(), it) }
+        val body = http.get("${'$'}BASE_URL/api/v3/depth") {
+            url {
+                parameters.append("symbol", symbol)
+                parameters.append("limit", limit.toString())
+            }
+        }.bodyAsText()
+        val root = json.parseToJsonElement(body).jsonObject
+        fun mapOrders(arr: JsonArray) = arr.map { item ->
+            val line = item.jsonArray
+            Order(
+                price = line[0].jsonPrimitive.double,
+                quantity = line[1].jsonPrimitive.double,
+            )
+        }
+        val depth = OrderBook(
+            bids = mapOrders(root["bids"]!!.jsonArray),
+            asks = mapOrders(root["asks"]!!.jsonArray),
+        )
+        cache.set(key, json.encodeToString(OrderBook.serializer(), depth), 5)
+        return depth
+    }
+
+    suspend fun klines(symbol: String, interval: String, limit: Int = 500): List<Kline> {
+        val key = "bn:klines:$symbol:$interval:$limit"
+        cache.get(key)?.let { return json.decodeFromString(ListSerializer(Kline.serializer()), it) }
+        val body = http.get("${'$'}BASE_URL/api/v3/klines") {
+            url {
+                parameters.append("symbol", symbol)
+                parameters.append("interval", interval)
+                parameters.append("limit", limit.toString())
+            }
+        }.bodyAsText()
+        val arr = json.parseToJsonElement(body).jsonArray
+        val klines = arr.map {
+            val k = it.jsonArray
+            Kline(
+                openTime = k[0].jsonPrimitive.long,
+                open = k[1].jsonPrimitive.double,
+                high = k[2].jsonPrimitive.double,
+                low = k[3].jsonPrimitive.double,
+                close = k[4].jsonPrimitive.double,
+                volume = k[5].jsonPrimitive.double,
+                closeTime = k[6].jsonPrimitive.long,
+            )
+        }
+        cache.set(key, json.encodeToString(ListSerializer(Kline.serializer()), klines), 60)
+        return klines
+    }
+}
+

--- a/clients/src/main/kotlin/pl/bot/clients/coingecko/CoinGeckoClient.kt
+++ b/clients/src/main/kotlin/pl/bot/clients/coingecko/CoinGeckoClient.kt
@@ -1,0 +1,87 @@
+package pl.bot.clients.coingecko
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.parameters
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import pl.bot.clients.cache.Cache
+
+private const val BASE_URL = "https://api.coingecko.com/api/v3"
+private const val TTL_SECONDS = 60L
+
+@Serializable
+data class MarketCoin(
+    val id: String,
+    val symbol: String,
+    val name: String,
+    @kotlinx.serialization.SerialName("current_price") val currentPrice: Double,
+    @kotlinx.serialization.SerialName("price_change_percentage_24h") val priceChangePercentage24h: Double,
+)
+
+class CoinGeckoClient(
+    private val cache: Cache,
+    engine: HttpClientEngine = CIO.create(),
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+    private val http = HttpClient(engine) {
+        install(ContentNegotiation) { json(json) }
+        install(HttpTimeout) {
+            requestTimeoutMillis = 5_000
+            connectTimeoutMillis = 5_000
+            socketTimeoutMillis = 5_000
+        }
+        install(HttpRequestRetry) {
+            retryOnExceptionOrServerErrors(maxRetries = 2)
+            exponentialDelay()
+        }
+    }
+
+    suspend fun simplePrice(ids: List<String>, vs: List<String> = listOf("usd", "rub")): Map<String, Map<String, Double>> {
+        val key = "cg:simple:${ids.joinToString(",")}:${vs.joinToString(",")}" 
+        cache.get(key)?.let {
+            return json.decodeFromString(MapSerializer(String.serializer(), MapSerializer(String.serializer(), Double.serializer())), it)
+        }
+        val body = http.get("${'$'}BASE_URL/simple/price") {
+            url {
+                parameters.append("ids", ids.joinToString(","))
+                parameters.append("vs_currencies", vs.joinToString(","))
+            }
+        }.bodyAsText()
+        val result = json.decodeFromString(MapSerializer(String.serializer(), MapSerializer(String.serializer(), Double.serializer())), body)
+        cache.set(key, body, TTL_SECONDS)
+        return result
+    }
+
+    suspend fun marketsTopGainers(limit: Int = 10): List<MarketCoin> {
+        val key = "cg:top:$limit"
+        cache.get(key)?.let {
+            return json.decodeFromString(ListSerializer(MarketCoin.serializer()), it)
+        }
+        val body = http.get("${'$'}BASE_URL/coins/markets") {
+            url {
+                parameters.append("vs_currency", "usd")
+                parameters.append("order", "market_cap_desc")
+                parameters.append("per_page", "250")
+                parameters.append("page", "1")
+                parameters.append("price_change_percentage", "24h")
+            }
+        }.bodyAsText()
+        val markets = json.decodeFromString(ListSerializer(MarketCoin.serializer()), body)
+            .sortedByDescending { it.priceChangePercentage24h }
+            .take(limit)
+        cache.set(key, json.encodeToString(ListSerializer(MarketCoin.serializer()), markets), TTL_SECONDS)
+        return markets
+    }
+}
+

--- a/clients/src/main/kotlin/pl/bot/clients/feargreed/FearGreedClient.kt
+++ b/clients/src/main/kotlin/pl/bot/clients/feargreed/FearGreedClient.kt
@@ -1,0 +1,54 @@
+package pl.bot.clients.feargreed
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.parameters
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.int
+import pl.bot.clients.cache.Cache
+
+private const val BASE_URL = "https://api.alternative.me/fng/"
+private const val TTL_SECONDS = 60L
+
+class FearGreedClient(
+    private val cache: Cache,
+    engine: HttpClientEngine = CIO.create(),
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+    private val http = HttpClient(engine) {
+        install(ContentNegotiation) { json(json) }
+        install(HttpTimeout) {
+            requestTimeoutMillis = 5_000
+            connectTimeoutMillis = 5_000
+            socketTimeoutMillis = 5_000
+        }
+        install(HttpRequestRetry) {
+            retryOnExceptionOrServerErrors(maxRetries = 2)
+            exponentialDelay()
+        }
+    }
+
+    suspend fun current(): Int {
+        val key = "fng:current"
+        cache.get(key)?.let { return it.toInt() }
+        val body = http.get(BASE_URL) {
+            url { parameters.append("limit", "1") }
+        }.bodyAsText()
+        val value = json.parseToJsonElement(body)
+            .jsonObject["data"]!!.jsonArray.first().jsonObject["value"]!!.jsonPrimitive.int
+        cache.set(key, value.toString(), TTL_SECONDS)
+        return value
+        
+    }
+}
+

--- a/clients/src/main/kotlin/pl/bot/clients/whalealert/WhaleAlertClient.kt
+++ b/clients/src/main/kotlin/pl/bot/clients/whalealert/WhaleAlertClient.kt
@@ -1,0 +1,103 @@
+package pl.bot.clients.whalealert
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.parameters
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.long
+import pl.bot.clients.cache.Cache
+
+private const val BASE_URL = "https://api.whale-alert.io/v1"
+private const val TTL_SECONDS = 60L
+private const val MIN_INTERVAL_MS = 20_000L
+
+@Serializable
+data class Transfer(
+    val blockchain: String,
+    val symbol: String,
+    val hash: String,
+    val from: String?,
+    val to: String?,
+    val amount: Double,
+    @kotlinx.serialization.SerialName("amount_usd") val amountUsd: Double,
+    val timestamp: Long,
+)
+
+class WhaleAlertClient(
+    private val apiKey: String,
+    private val cache: Cache,
+    engine: HttpClientEngine = CIO.create(),
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+    private val http = HttpClient(engine) {
+        install(ContentNegotiation) { json(json) }
+        install(HttpTimeout) {
+            requestTimeoutMillis = 5_000
+            connectTimeoutMillis = 5_000
+            socketTimeoutMillis = 5_000
+        }
+        install(HttpRequestRetry) {
+            retryOnExceptionOrServerErrors(maxRetries = 2)
+            exponentialDelay()
+        }
+    }
+
+    private val mutex = Mutex()
+    private var lastRequest = 0L
+
+    private suspend fun throttle() {
+        mutex.withLock {
+            val now = System.currentTimeMillis()
+            val wait = lastRequest + MIN_INTERVAL_MS - now
+            if (wait > 0) delay(wait)
+            lastRequest = System.currentTimeMillis()
+        }
+    }
+
+    suspend fun getTransfers(minUsd: Int, assets: String? = null): List<Transfer> {
+        val key = "whale:$minUsd:$assets"
+        cache.get(key)?.let { return json.decodeFromString(ListSerializer(Transfer.serializer()), it) }
+        throttle()
+        val body = http.get("${'$'}BASE_URL/transactions") {
+            url {
+                parameters.append("api_key", apiKey)
+                parameters.append("min_value", minUsd.toString())
+                parameters.append("start", ((System.currentTimeMillis()/1000) - 3600).toString())
+                if (assets != null) parameters.append("currency", assets)
+            }
+        }.bodyAsText()
+        val root = json.parseToJsonElement(body).jsonObject
+        val txs = root["transactions"]?.jsonArray?.map { item ->
+            val obj = item.jsonObject
+            Transfer(
+                blockchain = obj["blockchain"]!!.jsonPrimitive.content,
+                symbol = obj["symbol"]!!.jsonPrimitive.content,
+                hash = obj["hash"]!!.jsonPrimitive.content,
+                from = obj["from"]?.jsonObject?.get("address")?.jsonPrimitive?.content,
+                to = obj["to"]?.jsonObject?.get("address")?.jsonPrimitive?.content,
+                amount = obj["amount"]!!.jsonPrimitive.double,
+                amountUsd = obj["amount_usd"]!!.jsonPrimitive.double,
+                timestamp = obj["timestamp"]!!.jsonPrimitive.long,
+            )
+        } ?: emptyList()
+        cache.set(key, json.encodeToString(ListSerializer(Transfer.serializer()), txs), TTL_SECONDS)
+        return txs
+    }
+}
+


### PR DESCRIPTION
## Summary
- add CoinGeckoClient with price lookup and market gainers
- add BinanceClient for ticker, order book and kline data
- add FearGreedClient to fetch current index
- add WhaleAlertClient for large transfer monitoring

## Testing
- `./gradlew clients:test`


------
https://chatgpt.com/codex/tasks/task_e_6898103107448321b68aba164c5a8b71