### PR TITLE
Add quote and crypto quote handlers with daily limits

### DIFF
--- a/bot/src/test/kotlin/pl/bot/bot/QuoteHandlersTest.kt
+++ b/bot/src/test/kotlin/pl/bot/bot/QuoteHandlersTest.kt
@@ -1,0 +1,69 @@
+package pl.bot.bot
+
+import com.pengrad.telegrambot.request.SendMessage
+import com.pengrad.telegrambot.utility.BotUtils
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import pl.bot.core.crypto.CryptoQuote
+import pl.bot.core.crypto.CryptoQuoteService
+import pl.bot.core.quote.Quote
+import pl.bot.core.quote.QuoteService
+
+class QuoteHandlersTest {
+    private lateinit var bot: FakeTelegramBot
+
+    @BeforeEach
+    fun setup() { bot = FakeTelegramBot() }
+
+    @AfterEach
+    fun teardown() { stopKoin() }
+
+    @Test
+    fun `quote formats html with emoji`() {
+        val updateJson = """
+            {"update_id":1,
+             "message":{"message_id":1,
+                        "from":{"id":1,"is_bot":false,"first_name":"A"},
+                        "chat":{"id":1,"type":"private"},
+                        "date":0,
+                        "text":"/quote SBER"}}
+        """.trimIndent()
+        val update = BotUtils.fromJson(updateJson, com.pengrad.telegrambot.model.Update::class.java)
+        val service = object : QuoteService {
+            override suspend fun getQuote(secid: String) = Quote(100.0, -1.0, 50)
+        }
+        startKoin { modules(module { single<QuoteService> { service } }) }
+        quote(bot, update)
+        val req = bot.lastRequest as SendMessage
+        val text = req.parameters["text"] as String
+        assertTrue(text.contains("📉"))
+        assertTrue(req.parameters["parse_mode"] == "HTML")
+    }
+
+    @Test
+    fun `cquote formats html with emoji`() {
+        val updateJson = """
+            {"update_id":1,
+             "message":{"message_id":1,
+                        "from":{"id":1,"is_bot":false,"first_name":"A"},
+                        "chat":{"id":1,"type":"private"},
+                        "date":0,
+                        "text":"/cquote BTC"}}
+        """.trimIndent()
+        val update = BotUtils.fromJson(updateJson, com.pengrad.telegrambot.model.Update::class.java)
+        val service = object : CryptoQuoteService {
+            override suspend fun getQuote(symbol: String) = CryptoQuote(20000.0, 2.0)
+        }
+        startKoin { modules(module { single<CryptoQuoteService> { service } }) }
+        cquote(bot, update)
+        val req = bot.lastRequest as SendMessage
+        val text = req.parameters["text"] as String
+        assertTrue(text.contains("📈"))
+        assertTrue(req.parameters["parse_mode"] == "HTML")
+    }
+}

--- a/clients/build.gradle.kts
+++ b/clients/build.gradle.kts
@@ -1,7 +1,6 @@
 val ktorVersion = "2.3.8"
 
 dependencies {
-    implementation(project(":core"))
     implementation("io.ktor:ktor-client-core:$ktorVersion")
     implementation("io.ktor:ktor-client-cio:$ktorVersion")
     implementation("io.ktor:ktor-client-websockets:$ktorVersion")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,1 +1,5 @@
 // Core module: domain models and use cases
+
+dependencies {
+    implementation(project(":clients"))
+}

--- a/core/src/main/kotlin/pl/bot/core/crypto/CryptoQuoteService.kt
+++ b/core/src/main/kotlin/pl/bot/core/crypto/CryptoQuoteService.kt
@@ -1,0 +1,28 @@
+package pl.bot.core.crypto
+
+import pl.bot.clients.coingecko.CoinGeckoClient
+
+/** Crypto quote data. */
+data class CryptoQuote(
+    val price: Double,
+    val change24h: Double,
+)
+
+interface CryptoQuoteService {
+    suspend fun getQuote(symbol: String): CryptoQuote?
+}
+
+class RealCryptoQuoteService(
+    private val cg: CoinGeckoClient,
+) : CryptoQuoteService {
+    override suspend fun getQuote(symbol: String): CryptoQuote? {
+        val id = when (symbol.uppercase()) {
+            "BTC" -> "bitcoin"
+            else -> symbol.lowercase()
+        }
+        val map = cg.simplePrice(listOf(id), listOf("usd"), include24hChange = true)[id] ?: return null
+        val price = map["usd"] ?: return null
+        val change = map["usd_24h_change"] ?: 0.0
+        return CryptoQuote(price, change)
+    }
+}

--- a/core/src/main/kotlin/pl/bot/core/quote/QuoteService.kt
+++ b/core/src/main/kotlin/pl/bot/core/quote/QuoteService.kt
@@ -1,0 +1,45 @@
+package pl.bot.core.quote
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import pl.bot.clients.cache.Cache
+import pl.bot.clients.moex.MoexIssClient
+
+/** Quote data. */
+data class Quote(
+    val price: Double,
+    val dayChangePercent: Double,
+    val volume: Long,
+)
+
+interface QuoteService {
+    suspend fun getQuote(secid: String): Quote?
+}
+
+class RealQuoteService(
+    private val cache: Cache,
+    private val moex: MoexIssClient,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) : QuoteService {
+    @Serializable
+    private data class Tick(
+        val price: Double,
+        val dayChangePercent: Double,
+        val volume: Long,
+        val ts: Long,
+    )
+
+    override suspend fun getQuote(secid: String): Quote? {
+        cache.get("tinkoff:quote:$secid")?.let {
+            val tick = json.decodeFromString(Tick.serializer(), it)
+            val now = System.currentTimeMillis() / 1000
+            if (now - tick.ts <= 5) {
+                return Quote(tick.price, tick.dayChangePercent, tick.volume)
+            }
+        }
+        val candles = moex.getOHLCV(secid, "24")
+        val last = candles.lastOrNull() ?: return null
+        val pct = if (last.open != 0.0) ((last.close - last.open) / last.open) * 100.0 else 0.0
+        return Quote(last.close, pct, last.volume)
+    }
+}

--- a/core/src/test/kotlin/pl/bot/core/QuoteServiceTest.kt
+++ b/core/src/test/kotlin/pl/bot/core/QuoteServiceTest.kt
@@ -1,0 +1,46 @@
+package pl.bot.core
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import pl.bot.clients.cache.InMemoryCache
+import pl.bot.clients.moex.Candle
+import pl.bot.clients.moex.MoexIssClient
+import pl.bot.core.quote.RealQuoteService
+
+class QuoteServiceTest {
+    @Test
+    fun `uses tinkoff tick when fresh`() = runBlocking {
+        val cache = InMemoryCache()
+        val moex = mockk<MoexIssClient>(relaxed = true)
+        val service = RealQuoteService(cache, moex)
+        val ts = System.currentTimeMillis() / 1000
+        val json = "{" +
+            "\"price\":100.0,\"dayChangePercent\":1.0,\"volume\":10,\"ts\":$ts" +
+            "}"
+        cache.set("tinkoff:quote:SBER", json, 60)
+        val quote = service.getQuote("SBER")!!
+        assertEquals(100.0, quote.price)
+        coVerify(exactly = 0) { moex.getOHLCV(any(), any()) }
+    }
+
+    @Test
+    fun `falls back to moex when no tick`() = runBlocking {
+        val cache = InMemoryCache()
+        val moex = mockk<MoexIssClient>()
+        val candles = listOf(
+            Candle(open = 10.0, close = 11.0, high = 0.0, low = 0.0, volume = 5, begin = "", end = ""),
+        )
+        coEvery { moex.getOHLCV("SBER", "24") } returns candles
+        val service = RealQuoteService(cache, moex)
+        val quote = service.getQuote("SBER")!!
+        assertEquals(11.0, quote.price)
+        assertEquals(10.0, quote.dayChangePercent)
+        assertEquals(5, quote.volume)
+        coVerify(exactly = 1) { moex.getOHLCV("SBER", "24") }
+    }
+}

--- a/infra/build.gradle.kts
+++ b/infra/build.gradle.kts
@@ -1,3 +1,5 @@
+val ktorVersion = "2.3.8"
+
 dependencies {
     implementation(project(":core"))
     implementation(project(":clients"))
@@ -8,4 +10,6 @@ dependencies {
     implementation("ch.qos.logback:logback-classic:1.4.14")
     implementation("io.lettuce:lettuce-core:6.8.0.RELEASE")
     implementation("io.sentry:sentry:8.18.0")
+    implementation("io.ktor:ktor-client-core:$ktorVersion")
+    implementation("io.ktor:ktor-client-cio:$ktorVersion")
 }

--- a/infra/src/main/kotlin/DI.kt
+++ b/infra/src/main/kotlin/DI.kt
@@ -1,18 +1,24 @@
 package pl.bot.infra
 
 import org.koin.dsl.module
-import pl.bot.clients.ClientsPlaceholder
-import pl.bot.data.DataPlaceholder
-import pl.bot.core.CorePlaceholder
+import pl.bot.clients.cache.Cache
+import pl.bot.clients.cache.InMemoryCache
+import pl.bot.clients.coingecko.CoinGeckoClient
+import pl.bot.clients.moex.MoexIssClient
+import pl.bot.core.crypto.CryptoQuoteService
+import pl.bot.core.crypto.RealCryptoQuoteService
+import pl.bot.core.quote.QuoteService
+import pl.bot.core.quote.RealQuoteService
 
 val clientsModule = module {
-    single { ClientsPlaceholder }
+    single<Cache> { InMemoryCache() }
+    single { MoexIssClient(get()) }
+    single { CoinGeckoClient(get()) }
 }
 
-val repositoriesModule = module {
-    single { DataPlaceholder }
-}
+val repositoriesModule = module { }
 
 val servicesModule = module {
-    single { CorePlaceholder }
+    single<QuoteService> { RealQuoteService(get(), get()) }
+    single<CryptoQuoteService> { RealCryptoQuoteService(get()) }
 }


### PR DESCRIPTION
## Summary
- implement `/quote` for stock price, day change and volume
- add `/cquote` for crypto price and 24h change from CoinGecko
- enforce daily limits with upgrade suggestion and wire Koin services

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6898135300148321981e85555ba6b605